### PR TITLE
Changed cycle integral to be (lastError + error)/2, not last error + error/2

### DIFF
--- a/c/PID.c
+++ b/c/PID.c
@@ -174,7 +174,7 @@ void tick(PIDController *c) {
 			long deltaTime = c->currentTime - c->lastTime;
 
 			// Calculate the integral of the feedback data since last cycle.
-			int cycleIntegral = (c->lastError + c->error / 2) * deltaTime;
+			int cycleIntegral = ((c->lastError + c->error) / 2) * deltaTime;
 
 			// Add this cycle's integral to the integral cumulation.
 			c->integralCumulation += cycleIntegral;

--- a/cpp/PID.cpp
+++ b/cpp/PID.cpp
@@ -182,7 +182,7 @@ void PIDController<T>::tick()
       long deltaTime = currentTime - lastTime;
 
       //Calculate the integral of the feedback data since last cycle.
-      int cycleIntegral = (lastError + error / 2) * deltaTime;
+      int cycleIntegral = ((lastError + error) / 2) * deltaTime;
 
       //Add this cycle's integral to the integral cumulation.
       integralCumulation += cycleIntegral;


### PR DESCRIPTION
According to wikipedia PID cycle error is error * deltaTime. Implementation uses error smoothing and point in between last and current error. Though it reads lastError + error/2. Changed it to explicitly read (lastError+error)/2.