### PR TITLE
changed callback functions from pointer type to std::function

### DIFF
--- a/cpp/PID.cpp
+++ b/cpp/PID.cpp
@@ -56,6 +56,7 @@
 
 #include "PID.h"
 
+
 /**
  * Constructs the PIDController object with PID Gains and function pointers
  * for retrieving feedback (pidSource) and delivering output (pidOutput).
@@ -68,7 +69,7 @@
  * @param (*pidOutput) The function pointer for delivering system output.
  */
 template <class T>
-PIDController<T>::PIDController(double p, double i, double d, T (*pidSource)(), void (*pidOutput)(T output))
+PIDController<T>::PIDController(double p, double i, double d, std::function<T()> pidSource, std::function<void(T output)>)
 {
   _p = p;
   _i = i;
@@ -95,8 +96,9 @@ PIDController<T>::PIDController(double p, double i, double d, T (*pidSource)(), 
   feedbackWrapped = false;
 
   timeFunctionRegistered = false;
-  _pidSource = pidSource;
-  _pidOutput = pidOutput;
+  
+  _pidSource.swap(pidSource);
+  _pidOutput.swap(pidSource);
 }
 
 /**

--- a/cpp/PID.h
+++ b/cpp/PID.h
@@ -1,12 +1,13 @@
 #ifndef PID_H
 #define PID_H
 #endif
+#include <functional>
 
 template <class T>
 class PIDController
 {
 public:
-  PIDController(double p, double i, double d, T (*pidSource)(), void (*pidOutput)(T output));
+  PIDController(double p, double i, double d, std::function<T()> pidSource, std::function<void(T output)>);
   void tick();
   void setTarget(T t);
   T getTarget();
@@ -76,7 +77,7 @@ private:
   T feedbackWrapUpperBound;
 
   bool timeFunctionRegistered;
-  T (*_pidSource)();
-  void (*_pidOutput)(T output);
+  std::function<T()> _pidSource;
+  std::function<void(T output)> _pidOutput;
   unsigned long (*_getSystemTime)();
 };


### PR DESCRIPTION
when developing with c++, it would be good to be able to easily use non static member functions as output/source functions. This commit changes the pointer type to std::function in order to solve this problem.