### PR TITLE
Fix calculation that should use absolute value

### DIFF
--- a/cpp/PID.cpp
+++ b/cpp/PID.cpp
@@ -176,7 +176,7 @@ T PIDController<T>::tick()
       float altErr2Abs = (altErr2 >= 0) ? altErr2 : -altErr2;
 
       //Use the error with the smallest absolute value
-      if(regErrAbs <= altErr1Abs && regErr <= altErr2Abs) //If reguErrAbs is smallest
+      if(regErrAbs <= altErr1Abs && regErrAbs <= altErr2Abs) //If reguErrAbs is smallest
       {
         error = regErr;
       }


### PR DESCRIPTION
While reviewing #8 I noticed here that I think this calculation should be using the absolute value of the "regular error".