### PR TITLE
Fix for issue #11

### DIFF
--- a/c/PID.c
+++ b/c/PID.c
@@ -154,10 +154,11 @@ void tick(PIDController *c) {
 				c->error = regErr;
 			}
 			else if(altErr1Abs < regErrAbs && altErr1Abs < altErr2Abs) {
-				c->error = altErr1Abs;
+				c->error = altErr1;
 			}
 			else if(altErr2Abs < regErrAbs && altErr2Abs < altErr1Abs) {
-				c->error = altErr2Abs;
+                // This path is necesarily in the reverse direction, so we add a negative sign here
+				c->error = -altErr2;
 			}
 		}
 		else {

--- a/cpp/PID.cpp
+++ b/cpp/PID.cpp
@@ -56,7 +56,6 @@
 
 #include "PID.h"
 
-
 /**
  * Constructs the PIDController object with PID Gains and function pointers
  * for retrieving feedback (pidSource) and delivering output (pidOutput).
@@ -298,6 +297,16 @@ template <class T>
 T PIDController<T>::getError()
 {
   return error;
+}
+
+/**
+ * Returns the previsou calculated error of this PIDController.
+ * @return The previsou calculated error of this PIDController.
+ */
+template <class T>
+T PIDController<T>::getLastError()
+{
+  return lastError;
 }
 
 /**
@@ -715,6 +724,7 @@ void PIDController<T>::registerTimeFunction(unsigned long (*getSystemTime)())
 {
   _getSystemTime = getSystemTime;
   timeFunctionRegistered = true;
+  lastTime = _getSystemTime();
 }
 
 /*

--- a/cpp/PID.cpp
+++ b/cpp/PID.cpp
@@ -182,11 +182,12 @@ T PIDController<T>::tick()
       }
       else if(altErr1Abs < regErrAbs && altErr1Abs < altErr2Abs) //If altErr1Abs is smallest
       {
-        error = altErr1Abs;
+        error = altErr1;
       }
       else if(altErr2Abs < regErrAbs && altErr2Abs < altErr1Abs) //If altErr2Abs is smallest
       {
-        error = altErr2Abs;
+        // This path is necesarily in the reverse direction, so we add a negative sign here
+        error = -altErr2;
       }
     }
     else

--- a/cpp/PID.h
+++ b/cpp/PID.h
@@ -14,6 +14,7 @@ public:
   T getOutput();
   T getFeedback();
   T getError();
+  T getLastError();
   void setEnabled(bool e);
   bool isEnabled();
   T getProportionalComponent();


### PR DESCRIPTION
The original code produces the wrong sign for the error for wrap paths two and three under at least some circumstances. This commit fixes that by doing two things:

-- Assigning the signed rather than absolute versions of `altErr1` and `altErr2` to error in their respective branches.
-- Reversed the sign of  `altErr2`, because the original calculation consistently produces the wrong sign.